### PR TITLE
Add v3 licensing info to intro

### DIFF
--- a/versioned_docs/version-3/intro.mdx
+++ b/versioned_docs/version-3/intro.mdx
@@ -11,7 +11,12 @@ The documentation for TCAdmin v3 is currently in development.
 
 ## v3 Preview
 
-You can preview TCAdmin v3 using your existing v2 master license on the same server. This allows you to explore the new features and interface before the official release.
+
+:::info Licensing
+You can use your existing TCAdmin **v2** master license to activate TCAdmin **v3** on the same machine. This lets you install TCAdmin v3 alongside TCAdmin v2 so you can run both versions at the same time, or install only v3 on that server and use your v2 license there.
+
+If you want to install TCAdmin v3 on a different machine than the one your v2 license is assigned to, you will need a separate TCAdmin v2 trial key for that machine. Contact our sales or support team to request a trial key for evaluation on a separate server.
+:::
 
 ## What's New in v3
 


### PR DESCRIPTION
Add an info admonition to the v3 intro explaining licensing: existing TCAdmin v2 master licenses can activate TCAdmin v3 on the same machine (allowing side-by-side or replacement installs). If you need to install v3 on a different machine, a separate TCAdmin v2 trial key is required—contact sales or support to request one.