### PR TITLE
Add releases plugin and list component

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,6 +35,28 @@ const config = {
           routeBasePath: "/",
           sidebarPath: "./sidebars.js",
           showLastUpdateTime: true,
+          // @ts-ignore
+          async sidebarItemsGenerator({ defaultSidebarItemsGenerator, ...args }) {
+            const items = await defaultSidebarItemsGenerator(args);
+            /** @param {any[]} items */
+            function sortItems(items) {
+              return items.map((/** @type {any} */ item) => {
+                if (item.type === "category") {
+                  const sorted = /** @type {any[]} */ (sortItems(item.items));
+                  if (item.label === "Release Notes") {
+                    sorted.sort((/** @type {any} */ a, /** @type {any} */ b) => {
+                      const la = a.label ?? "";
+                      const lb = b.label ?? "";
+                      return lb < la ? -1 : lb > la ? 1 : 0;
+                    });
+                  }
+                  return { ...item, items: sorted };
+                }
+                return item;
+              });
+            }
+            return sortItems(items);
+          },
           editUrl:
             "https://github.com/TotalControlAdmin/tcadmin-docs/blob/master/",
           lastVersion: "2",
@@ -56,6 +78,10 @@ const config = {
         },
       },
     ],
+  ],
+
+  plugins: [
+    "./plugins/releases-data-plugin",
   ],
 
   themes: ["docusaurus-theme-search-typesense"],

--- a/plugins/releases-data-plugin.js
+++ b/plugins/releases-data-plugin.js
@@ -1,0 +1,91 @@
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const RELEASES_DIR_REL = path.join("versioned_docs", "version-3", "releases");
+
+function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function generateDescription(content) {
+  const featuresMatch = content.match(/###\s+New Features([\s\S]*?)(?:###|$)/);
+  if (!featuresMatch) return "";
+  const names = [];
+  const re = /\*\*([^*]+)\*\*/g;
+  let m;
+  while ((m = re.exec(featuresMatch[1])) !== null) {
+    names.push(m[1]);
+    if (names.length === 5) break;
+  }
+  return names.length ? names.join(", ") + (names.length === 5 ? ", and more." : ".") : "";
+}
+
+function getReleases(siteDir) {
+  const releasesDir = path.join(siteDir, RELEASES_DIR_REL);
+  return fs
+    .readdirSync(releasesDir)
+    .filter((f) => (f.endsWith(".mdx") || f.endsWith(".md")) && f !== "index.mdx")
+    .sort()
+    .reverse()
+    .map((file) => {
+      const raw = fs.readFileSync(path.join(releasesDir, file), "utf8");
+      const { data, content } = matter(raw);
+      const slug = path.basename(file).replace(/\.(mdx|md)$/, "");
+      return {
+        title: data.sidebar_label ?? data.title ?? slug,
+        date: data.date ? new Date(data.date).toISOString() : null,
+        description: data.description || generateDescription(content),
+        slug,
+        id: file,
+      };
+    });
+}
+
+function generateRSS(releases, siteUrl) {
+  const items = releases
+    .filter((r) => r.date)
+    .map(
+      (r) =>
+        `\n    <item>\n      <title>${escapeXml(r.title)}</title>\n      <link>${siteUrl}/3/releases/${escapeXml(r.slug)}</link>\n      <guid isPermaLink="true">${siteUrl}/3/releases/${escapeXml(r.slug)}</guid>\n      <description>${escapeXml(r.description)}</description>\n      <pubDate>${new Date(r.date).toUTCString()}</pubDate>\n    </item>`
+    )
+    .join("");
+  const lastBuild = releases[0]?.date ? new Date(releases[0].date).toUTCString() : new Date().toUTCString();
+  const year = new Date().getFullYear();
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n  <channel>\n    <title>TCAdmin v3 Releases</title>\n    <link>${siteUrl}/3/releases</link>\n    <description>Latest TCAdmin v3 release notes</description>\n    <language>en</language>\n    <lastBuildDate>${lastBuild}</lastBuildDate>\n    <atom:link href="${siteUrl}/releases/rss.xml" rel="self" type="application/rss+xml"/>\n    <copyright>Copyright \u00a9 ${year} TCADMIN.COM</copyright>${items}\n  </channel>\n</rss>`;
+}
+
+function generateAtom(releases, siteUrl) {
+  const entries = releases
+    .filter((r) => r.date)
+    .map(
+      (r) =>
+        `\n  <entry>\n    <title>${escapeXml(r.title)}</title>\n    <link href="${siteUrl}/3/releases/${escapeXml(r.slug)}"/>\n    <id>${siteUrl}/3/releases/${escapeXml(r.slug)}</id>\n    <updated>${r.date}</updated>\n    <summary>${escapeXml(r.description)}</summary>\n  </entry>`
+    )
+    .join("");
+  const updated = releases.find((r) => r.date)?.date ?? new Date().toISOString();
+  const year = new Date().getFullYear();
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<feed xmlns="http://www.w3.org/2005/Atom">\n  <title>TCAdmin v3 Releases</title>\n  <link href="${siteUrl}/3/releases"/>\n  <link rel="self" href="${siteUrl}/releases/atom.xml"/>\n  <id>${siteUrl}/releases/atom.xml</id>\n  <updated>${updated}</updated>\n  <rights>Copyright \u00a9 ${year} TCADMIN.COM</rights>${entries}\n</feed>`;
+}
+
+module.exports = function releasesDataPlugin(context) {
+  return {
+    name: "releases-data-plugin",
+    async contentLoaded({ actions }) {
+      const { setGlobalData } = actions;
+      setGlobalData({ releases: getReleases(context.siteDir) });
+    },
+    async postBuild({ outDir }) {
+      const releases = getReleases(context.siteDir);
+      const siteUrl = context.siteConfig.url;
+      const feedsDir = path.join(outDir, "releases");
+      fs.mkdirSync(feedsDir, { recursive: true });
+      fs.writeFileSync(path.join(feedsDir, "rss.xml"), generateRSS(releases, siteUrl));
+      fs.writeFileSync(path.join(feedsDir, "atom.xml"), generateAtom(releases, siteUrl));
+    },
+  };
+};

--- a/src/components/ReleasesList.jsx
+++ b/src/components/ReleasesList.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { usePluginData } from "@docusaurus/useGlobalData";
+
+export default function ReleasesList() {
+  const { releases } = usePluginData("releases-data-plugin");
+
+  return (
+    <div className="releases-grid">
+      {releases.map(({ id, title, date, description, slug }) => (
+        <a key={id} href={`./${slug}`} className="release-card">
+          <div className="release-card__version">{title}</div>
+          {date && (
+            <div className="release-card__date">
+              {new Date(date).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </div>
+          )}
+          <div className="release-card__summary">{description}</div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/versioned_docs/version-3/releases/3.0.829.41981.mdx
+++ b/versioned_docs/version-3/releases/3.0.829.41981.mdx
@@ -1,6 +1,7 @@
 ---
-sidebar_position: 4
 sidebar_label: 3.0.829.41981
+date: 2026-02-06
+authors: [tcadmin]
 ---
 
 # Version 3.0.829.41981

--- a/versioned_docs/version-3/releases/3.0.867.2669.mdx
+++ b/versioned_docs/version-3/releases/3.0.867.2669.mdx
@@ -1,6 +1,7 @@
 ---
-sidebar_position: 3
 sidebar_label: 3.0.867.2669
+date: 2026-02-16
+authors: [tcadmin]
 ---
 
 # Version 3.0.867.2669

--- a/versioned_docs/version-3/releases/3.0.891.56055.mdx
+++ b/versioned_docs/version-3/releases/3.0.891.56055.mdx
@@ -1,6 +1,7 @@
 ---
-sidebar_position: 2
 sidebar_label: 3.0.891.56055
+date: 2026-02-24
+authors: [tcadmin]
 ---
 
 # Version 3.0.891.56055

--- a/versioned_docs/version-3/releases/3.1.62.57465.mdx
+++ b/versioned_docs/version-3/releases/3.1.62.57465.mdx
@@ -1,6 +1,7 @@
 ---
-sidebar_position: 1
 sidebar_label: 3.1.62.57465
+date: 2026-03-16
+authors: [tcadmin]
 ---
 
 # Version 3.1.62.57465

--- a/versioned_docs/version-3/releases/authors.yml
+++ b/versioned_docs/version-3/releases/authors.yml
@@ -1,0 +1,5 @@
+tcadmin:
+  name: TCAdmin
+  title: TCAdmin Team
+  url: https://www.tcadmin.com
+  image_url: https://docs.tcadmin.com/img/tcadmin-logo.png

--- a/versioned_docs/version-3/releases/index.mdx
+++ b/versioned_docs/version-3/releases/index.mdx
@@ -3,6 +3,8 @@ title: Release Notes
 sidebar_label: Release Notes
 ---
 
+import ReleasesList from "@site/src/components/ReleasesList.jsx";
+
 # Release Notes
 
 Release notes for TCAdmin v3 versions.
@@ -11,42 +13,6 @@ Release notes for TCAdmin v3 versions.
 See the [Update TCAdmin](../update-tcadmin.mdx) guide for step-by-step instructions on how to update your installation.
 :::
 
-export const ReleaseCard = ({version, date, summary, link}) => (
-  <a href={link} className="release-card">
-    <div className="release-card__version">{version}</div>
-    {date && <div className="release-card__date">{date}</div>}
-    <div className="release-card__summary">{summary}</div>
-  </a>
-);
+Subscribe to release updates: [RSS](https://docs.tcadmin.com/releases/rss.xml) · [Atom](https://docs.tcadmin.com/releases/atom.xml)
 
-<div className="releases-grid">
-
-<ReleaseCard
-  version="3.1.62.57465"
-  date="March 16, 2026"
-  summary="Virtual servers, .NET 10 upgrade, billing integration, S3 file provider, automatic server selection, datacenter regions, and more."
-  link="./3.1.62.57465"
-/>
-
-<ReleaseCard
-  version="3.0.891.56055"
-  date="February 24, 2026"
-  summary="Config file editors in service wizard, resource limits, service settings pages, update health check, and bug fixes."
-  link="./3.0.891.56055"
-/>
-
-<ReleaseCard
-  version="3.0.867.2669"
-  date="February 16, 2026"
-  summary="Encrypted credentials, private networks, remote desktop/shell, community plugin repository, and more."
-  link="./3.0.867.2669"
-/>
-
-<ReleaseCard
-  version="3.0.829.41981"
-  date="February 6, 2026"
-  summary="Initial preview release — redesigned Blazor interface and modular SDK architecture."
-  link="./3.0.829.41981"
-/>
-
-</div>
+<ReleasesList />


### PR DESCRIPTION
Introduce a releases-data-plugin that reads versioned release MDX files, exposes release metadata via global data, and generates RSS/Atom feeds in the built site. Add a React ReleasesList component that consumes the plugin data to render release cards and wire it into the releases index page. Update docusaurus.config.js to register the plugin and add a sidebarItemsGenerator to sort the "Release Notes" category in descending order. Also add authors.yml and add date/authors frontmatter to several release docs, and replace the manual release cards in index.mdx with the dynamic ReleasesList plus RSS/Atom subscribe links.