### PR TITLE
Add ReleaseDate component and modernize deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,27 +14,16 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
+          cache: 'npm'
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-website-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-website-
-
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
+      - run: npm ci
+      - run: npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/src/components/ReleaseDate.jsx
+++ b/src/components/ReleaseDate.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+
+export default function ReleaseDate() {
+  const { frontMatter } = useDoc();
+  if (!frontMatter.date) return null;
+
+  const date = frontMatter.date instanceof Date
+    ? frontMatter.date
+    : new Date(frontMatter.date + 'T00:00:00');
+
+  return (
+    <p>
+      {date.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })}
+    </p>
+  );
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,7 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
+export default {
+  ...MDXComponents,
+  ReleaseDate,
+};

--- a/versioned_docs/version-3/releases/3.0.829.41981.mdx
+++ b/versioned_docs/version-3/releases/3.0.829.41981.mdx
@@ -4,7 +4,11 @@ date: 2026-02-06
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.829.41981
+
+<ReleaseDate />
 
 *Initial preview release.*
 

--- a/versioned_docs/version-3/releases/3.0.867.2669.mdx
+++ b/versioned_docs/version-3/releases/3.0.867.2669.mdx
@@ -4,7 +4,11 @@ date: 2026-02-16
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.867.2669
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.0.891.56055.mdx
+++ b/versioned_docs/version-3/releases/3.0.891.56055.mdx
@@ -4,7 +4,11 @@ date: 2026-02-24
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.891.56055
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.1.62.57465.mdx
+++ b/versioned_docs/version-3/releases/3.1.62.57465.mdx
@@ -4,7 +4,11 @@ date: 2026-03-16
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.1.62.57465
+
+<ReleaseDate />
 
 ### New Features
 


### PR DESCRIPTION
This pull request introduces a new `ReleaseDate` React component to display formatted release dates in the documentation, updates the Node.js version and workflow steps for deployment, and integrates the new component into release notes. The most important changes are grouped below:

**Release Date Component and Integration:**

* Added a new `ReleaseDate` component in `src/components/ReleaseDate.jsx` that reads the release date from the document front matter and displays it in a human-readable format.
* Registered the `ReleaseDate` component in the MDX components mapping (`src/theme/MDXComponents.js`), making it available for use in MDX documents.
* Updated all recent release note files (e.g., `3.0.829.41981.mdx`, `3.0.867.2669.mdx`, `3.0.891.56055.mdx`, `3.1.62.57465.mdx`) to import and render the `ReleaseDate` component, ensuring consistent display of release dates. [[1]](diffhunk://#diff-7f894d75a1f7f4c42999b3cf1f522046742e78252eac56eab04d7ce6f3f18cbbR7-R12) [[2]](diffhunk://#diff-280741c0f0fa19295b7c98b3ab44082b2a3885cd9c2f51770ad4ebb280b6b42fR7-R12) [[3]](diffhunk://#diff-adb94117cde262041a185f5771b2322c809bb5ac42c00ab02678eceb62fc01f8R7-R12) [[4]](diffhunk://#diff-4a98299e900818d8ae55d12f54b911a60fbbcc35f95cd69bf52fa63183fba432R7-R12)

**CI/CD Workflow Improvements:**

* Updated the deployment workflow in `.github/workflows/deploy.yml` to use newer versions of `actions/checkout` and `actions/setup-node`, switched Node.js to version 24, enabled npm caching, and replaced Yarn with npm for dependency management and builds.