### PR TITLE
Add ReleaseDate component and modernize deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,27 +14,16 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
+          cache: 'npm'
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-website-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-website-
-
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
+      - run: npm ci
+      - run: npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/src/components/ReleaseDate.jsx
+++ b/src/components/ReleaseDate.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+
+export default function ReleaseDate() {
+  const { frontMatter } = useDoc();
+  if (!frontMatter.date) return null;
+
+  const date = frontMatter.date instanceof Date
+    ? frontMatter.date
+    : new Date(frontMatter.date + 'T00:00:00');
+
+  return (
+    <p>
+      {date.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })}
+    </p>
+  );
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,7 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
+export default {
+  ...MDXComponents,
+  ReleaseDate,
+};

--- a/versioned_docs/version-3/releases/3.0.829.41981.mdx
+++ b/versioned_docs/version-3/releases/3.0.829.41981.mdx
@@ -4,7 +4,11 @@ date: 2026-02-06
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.829.41981
+
+<ReleaseDate />
 
 *Initial preview release.*
 

--- a/versioned_docs/version-3/releases/3.0.867.2669.mdx
+++ b/versioned_docs/version-3/releases/3.0.867.2669.mdx
@@ -4,7 +4,11 @@ date: 2026-02-16
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.867.2669
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.0.891.56055.mdx
+++ b/versioned_docs/version-3/releases/3.0.891.56055.mdx
@@ -4,7 +4,11 @@ date: 2026-02-24
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.0.891.56055
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.1.62.57465.mdx
+++ b/versioned_docs/version-3/releases/3.1.62.57465.mdx
@@ -4,7 +4,11 @@ date: 2026-03-16
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.1.62.57465
+
+<ReleaseDate />
 
 ### New Features
 


### PR DESCRIPTION
This pull request introduces a new `ReleaseDate` React component to standardize and display release dates in documentation, updates the Node.js and GitHub Actions versions in the deployment workflow, and migrates the project from Yarn to npm for dependency management. The most important changes are grouped below:

**Release Date Display Integration:**

* Added the `ReleaseDate` React component (`src/components/ReleaseDate.jsx`) to render the release date from document frontmatter in a consistent, localized format.
* Registered the `ReleaseDate` component in the MDX components mapping (`src/theme/MDXComponents.js`), making it available for use in MDX files.
* Updated multiple release documentation files to import and display the `<ReleaseDate />` component, ensuring release dates are shown consistently:
  * `versioned_docs/version-3/releases/3.0.829.41981.mdx`
  * `versioned_docs/version-3/releases/3.0.867.2669.mdx`
  * `versioned_docs/version-3/releases/3.0.891.56055.mdx`
  * `versioned_docs/version-3/releases/3.1.62.57465.mdx`

**Build and Dependency Management Updates:**

* Updated the deployment workflow (`.github/workflows/deploy.yml`) to use newer versions of `actions/checkout` and `actions/setup-node` (v6), switched Node.js version to 24, enabled npm caching, and migrated from Yarn to npm for dependency installation and builds.