### PR TITLE
Add ReleaseDate component and standardize v3 release notes

### DIFF
--- a/versioned_docs/version-3/releases/3.2.34.21134.mdx
+++ b/versioned_docs/version-3/releases/3.2.34.21134.mdx
@@ -4,7 +4,11 @@ date: 2026-03-30
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.2.34.21134
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.3.88.44401.mdx
+++ b/versioned_docs/version-3/releases/3.3.88.44401.mdx
@@ -4,7 +4,11 @@ date: 2026-04-20
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.3.88.44401
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.4.35.6378.mdx
+++ b/versioned_docs/version-3/releases/3.4.35.6378.mdx
@@ -4,7 +4,11 @@ date: 2026-04-29
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.4.35.6378
+
+<ReleaseDate />
 
 ### New Features
 


### PR DESCRIPTION
This pull request updates the release notes documentation for several versions to display the release date in a consistent and dynamic way. The main change is the addition of the `ReleaseDate` component to each of the affected release note files.

**Documentation improvements:**

* `versioned_docs/version-3/releases/3.2.34.21134.mdx`, `versioned_docs/version-3/releases/3.3.88.44401.mdx`, `versioned_docs/version-3/releases/3.4.35.6378.mdx`: Imported and rendered the `ReleaseDate` component at the top of each release note file to standardize how release dates are displayed. [[1]](diffhunk://#diff-2da3a0d01c2b8b4e105d3503ea2414381b4fe0f02d1b5592f0150f67d80ec6f8R7-R12) [[2]](diffhunk://#diff-2e425087ae612dbbbe91838d37951c174de3321dca7a7276fbe569d690ef3a1aR7-R12) [[3]](diffhunk://#diff-eeedecfd6ca46ae63399350db684ff56823b6b48be723ca869ec754908bca392R7-R12)