### PR TITLE
Add ReleaseDate component to standardize v3 release notes

### DIFF
--- a/versioned_docs/version-3/releases/3.2.34.21134.mdx
+++ b/versioned_docs/version-3/releases/3.2.34.21134.mdx
@@ -4,7 +4,11 @@ date: 2026-03-30
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.2.34.21134
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.3.88.44401.mdx
+++ b/versioned_docs/version-3/releases/3.3.88.44401.mdx
@@ -4,7 +4,11 @@ date: 2026-04-20
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.3.88.44401
+
+<ReleaseDate />
 
 ### New Features
 

--- a/versioned_docs/version-3/releases/3.4.35.6378.mdx
+++ b/versioned_docs/version-3/releases/3.4.35.6378.mdx
@@ -4,7 +4,11 @@ date: 2026-04-29
 authors: [tcadmin]
 ---
 
+import ReleaseDate from '@site/src/components/ReleaseDate';
+
 # Version 3.4.35.6378
+
+<ReleaseDate />
 
 ### New Features
 


### PR DESCRIPTION
This pull request updates the release notes documentation for several versions by adding a standardized release date display. The main change is the inclusion of the `ReleaseDate` component at the top of each release note file, which helps ensure consistency and clarity in how release dates are shown.

**Documentation improvements:**

* Added `import ReleaseDate from '@site/src/components/ReleaseDate';` and included the `<ReleaseDate />` component to the top of the following versioned release note files for consistent release date formatting:
  * `versioned_docs/version-3/releases/3.2.34.21134.mdx`
  * `versioned_docs/version-3/releases/3.3.88.44401.mdx`
  * `versioned_docs/version-3/releases/3.4.35.6378.mdx`