### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -11,7 +11,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -23,9 +23,9 @@ jobs:
 
       - name: Set up Node.js
         if: steps.detect.outputs.files != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install gray-matter
         if: steps.detect.outputs.files != ''


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Discord release notifications to use the latest versions of key actions and Node.js. These changes help ensure better compatibility, security, and access to the latest features.

**Workflow dependency updates:**

* Updated `actions/checkout` from version 4 to version 6 in `.github/workflows/discord-release-notify.yml`.
* Updated `actions/setup-node` from version 4 to version 6 and changed the Node.js version from 22 to 24 in `.github/workflows/discord-release-notify.yml`.